### PR TITLE
Add hiscores as possible milestones.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
+	implementation 'org.jsoup:jsoup:1.22.1'
+
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion

--- a/src/main/java/com/antimated/MilestoneLevelsConfig.java
+++ b/src/main/java/com/antimated/MilestoneLevelsConfig.java
@@ -5,6 +5,7 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
+import net.runelite.client.hiscore.HiscoreEndpoint;
 import net.runelite.client.ui.JagexColors;
 
 @ConfigGroup(MilestoneLevelsConfig.CONFIG_GROUP)
@@ -134,9 +135,64 @@ public interface MilestoneLevelsConfig extends Config
 	}
 
 	@ConfigSection(
+		name = "Hiscore Ranks",
+		description = "All hiscore rank notification settings",
+		position = 300
+	)
+	String SECTION_LEADERBOARD = "leaderboardRanks";
+
+	@ConfigItem(
+		keyName = "notificationLeaderboardRankColor",
+		name = "Color",
+		description = "Changes the color of the notification title and text.",
+		section = SECTION_LEADERBOARD,
+		position = 0
+	)
+	default Color notificationLeaderboardRankColor()
+	{
+		return JagexColors.DARK_ORANGE_INTERFACE_TEXT;
+	}
+
+	@ConfigItem(
+		keyName = "notificationLeaderboardRankTitle",
+		name = "Title",
+		description = "Can include $rank, $xp, $player, and $skill variables.",
+		section = SECTION_LEADERBOARD,
+		position = 1
+	)
+	default String notificationLeaderboardRankTitle()
+	{
+		return "Hiscore rank milestone";
+	}
+
+	@ConfigItem(
+		keyName = "notificationLeaderboardRankText",
+		name = "Text",
+		description = "Can include $rank, $xp, $player, and $skill variables.",
+		section = SECTION_LEADERBOARD,
+		position = 2
+	)
+	default String notificationLeaderboardRankText()
+	{
+		return "Achieved rank $rank in $skill,\nsurpassing $name!";
+	}
+
+	@ConfigItem(
+		keyName = "hiscoreEndpoint",
+		name = "Leaderboard",
+		description = "Configures which leaderboard to use for rank notifications.",
+		section = SECTION_LEADERBOARD,
+		position = 3
+	)
+	default HiscoreEndpoint hiscoreEndpoint()
+	{
+		return HiscoreEndpoint.NORMAL;
+	}
+
+	@ConfigSection(
 		name = "Skills",
 		description = "Settings for what skills we want to display notifications on",
-		position = 300
+		position = 400
 	)
 	String SECTION_SKILLS = "skills";
 

--- a/src/main/java/com/antimated/MilestoneLevelsPlugin.java
+++ b/src/main/java/com/antimated/MilestoneLevelsPlugin.java
@@ -116,6 +116,7 @@ public class MilestoneLevelsPlugin extends Plugin
 			case LOGIN_SCREEN_AUTHENTICATOR:
 			case CONNECTION_LOST:
 				previousXpMap.clear();
+				leaderboardManager.reset();
 				break;
 		}
 

--- a/src/main/java/com/antimated/MilestoneLevelsPlugin.java
+++ b/src/main/java/com/antimated/MilestoneLevelsPlugin.java
@@ -291,59 +291,7 @@ public class MilestoneLevelsPlugin extends Plugin
 	 */
 	private boolean shouldNotifyForSkill(Skill skill)
 	{
-		switch (skill)
-		{
-			case ATTACK:
-				return config.showAttackNotifications();
-			case DEFENCE:
-				return config.showDefenceNotifications();
-			case STRENGTH:
-				return config.showStrengthNotifications();
-			case HITPOINTS:
-				return config.showHitpointsNotifications();
-			case RANGED:
-				return config.showRangedNotifications();
-			case PRAYER:
-				return config.showPrayerNotifications();
-			case MAGIC:
-				return config.showMagicNotifications();
-			case COOKING:
-				return config.showCookingNotifications();
-			case WOODCUTTING:
-				return config.showWoodcuttingNotifications();
-			case FLETCHING:
-				return config.showFletchingNotifications();
-			case FISHING:
-				return config.showFishingNotifications();
-			case FIREMAKING:
-				return config.showFiremakingNotifications();
-			case CRAFTING:
-				return config.showCraftingNotifications();
-			case SMITHING:
-				return config.showSmithingNotifications();
-			case MINING:
-				return config.showMiningNotifications();
-			case HERBLORE:
-				return config.showHerbloreNotifications();
-			case AGILITY:
-				return config.showAgilityNotifications();
-			case THIEVING:
-				return config.showThievingNotifications();
-			case SLAYER:
-				return config.showSlayerNotifications();
-			case FARMING:
-				return config.showFarmingNotifications();
-			case RUNECRAFT:
-				return config.showRunecraftNotifications();
-			case HUNTER:
-				return config.showHunterNotifications();
-			case CONSTRUCTION:
-				return config.showConstructionNotifications();
-			case SAILING:
-				return config.showSailingNotifications();
-		}
-
-		return true;
+		return Util.skillEnabledInConfig(config, skill);
 	}
 
 	public void migrate()

--- a/src/main/java/com/antimated/leaderboard/LeaderboardClient.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardClient.java
@@ -1,0 +1,70 @@
+package com.antimated.leaderboard;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import okhttp3.*;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+/**
+ * Facilitates making requests to the OSRS hiscores website, specifically for "leaderboard" pages under specific skills.
+ * The interface returns that data as `LeaderboardResult` objects, which currently must be assembled by parsing HTML
+ * pages with `LeaderboardParser`. This parsing is done because there is no known public-facing API for the leaderboard
+ * data.
+ */
+@Slf4j
+public class LeaderboardClient {
+    private final OkHttpClient client;
+    private final Gson gson;
+
+    @Inject
+    private LeaderboardClient(OkHttpClient client, Gson gson)
+    {
+        this.client = client;
+        this.gson = gson;
+    }
+
+    public CompletableFuture<LeaderboardResult> lookupAsync(Skill skill, int page, LeaderboardEndpoint endpoint) {
+        HttpUrl url = endpoint.getLeaderboardURL().newBuilder()
+            .addQueryParameter("table", String.valueOf(SkillTable.valueOf(skill.name()).tableNumber))
+            .addQueryParameter("page", String.valueOf(page))
+            .build();
+
+        Request request = new Request.Builder()
+            .url(url)
+            .build();
+
+        CompletableFuture<LeaderboardResult> future = new CompletableFuture<>();
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) { future.completeExceptionally(e); }
+            @Override
+            public void onResponse(Call call, Response response) throws IOException {
+                try (response) {
+                    LeaderboardResult result;
+                    try {
+                        String documentContents = response.body().string();
+                        result = LeaderboardParser.parseDocument(documentContents);
+                        future.complete(result);
+                    } catch (Exception e) {
+                        future.completeExceptionally(e);
+                    }
+                }
+            }
+        });
+
+        return future;
+    }
+
+
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardEndpoint.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardEndpoint.java
@@ -1,0 +1,30 @@
+package com.antimated.leaderboard;
+
+import lombok.Getter;
+import okhttp3.HttpUrl;
+
+/**
+ * Maps the various game modes to leaderboard domains on the OSRS hiscores website. This parallels `HiscoreEndpoint` in
+ * the RuneLite code base.
+ */
+@Getter
+public enum LeaderboardEndpoint {
+    NORMAL("Normal", "https://services.runescape.com/m=hiscore_oldschool/overall"),
+    IRONMAN("Ironman", "https://services.runescape.com/m=hiscore_oldschool_ironman/overall"),
+    HARDCORE_IRONMAN("Hardcore Ironman", "https://services.runescape.com/m=hiscore_oldschool_hardcore_ironman/overall"),
+    ULTIMATE_IRONMAN("Ultimate Ironman", "https://services.runescape.com/m=hiscore_oldschool_ultimate/overall"),
+    DEADMAN("Deadman", "https://services.runescape.com/m=hiscore_oldschool_deadman/overall"),
+    SEASONAL("Leagues", "https://services.runescape.com/m=hiscore_oldschool_seasonal/overall"),
+    TOURNAMENT("Tournament", "https://services.runescape.com/m=hiscore_oldschool_tournament/overall"),
+    FRESH_START_WORLD("Fresh Start", "https://secure.runescape.com/m=hiscore_oldschool_fresh_start/overall"),
+    PURE("1 Defence Pure", "https://secure.runescape.com/m=hiscore_oldschool_skiller_defence/overall"),
+    LEVEL_3_SKILLER("Level 3 Skiller", "https://secure.runescape.com/m=hiscore_oldschool_skiller/overall");
+
+    private final String name;
+    private final HttpUrl leaderboardURL;
+
+    LeaderboardEndpoint(String name, String leaderboardURL) {
+        this.name = name;
+        this.leaderboardURL = HttpUrl.get(leaderboardURL);
+    }
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardEntry.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardEntry.java
@@ -1,0 +1,18 @@
+package com.antimated.leaderboard;
+
+/**
+ * Represents a single row from the skill leaderboard tables on the OSRS hiscores website.
+ */
+public class LeaderboardEntry {
+    public LeaderboardEntry(String name, int rank, int level, int xp) {
+        this.name = name;
+        this.rank = rank;
+        this.level = level;
+        this.xp = xp;
+    }
+
+    public final String name;
+    public final int rank;
+    public final int level;
+    public final int xp;
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardManager.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardManager.java
@@ -1,0 +1,316 @@
+package com.antimated.leaderboard;
+
+import com.antimated.MilestoneLevelsConfig;
+import com.antimated.util.Util;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.GameState;
+import net.runelite.api.Skill;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.hiscore.HiscoreClient;
+import net.runelite.client.hiscore.HiscoreResult;
+import net.runelite.client.hiscore.HiscoreSkill;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+/**
+ * Issues requests and processes results from the OSRS hiscores website for each tracked skill to maintain lists of XP
+ * milestones. Also controls rate limiting and retries, to limit strain on the hiscores page.
+ * <p>
+ * The objective is to ensure that these lists keep up with the player gaining XP. To accomplish this, an arbitrary
+ * minimum list length is chosen `MINIMUM_LEADERBOARD_LIST_LENGTH`. If there are fewer milestones than the minimum list
+ * size for a given skill, the LeaderboardManager will issue a request for more leaderboard data. At most one active
+ * request may exist at a time for each skill.
+ * <p>
+ * All logic is performed on the main game thread as part of `onGameTick`, while requests are performed asynchronously.
+ * Because of the asynchronous nature, LeaderboardManager operates on a state machine to ensure correct sequencing of
+ * operations.
+ * <p>
+ * NOTE: the term `hiscore` already exists in RuneLite to indicate a player's specific hiscore page results. This class,
+ * and related classes continue to use the term `hiscore` in that way, though references may be made to the
+ * `hiscore servers`, which vaguely mean the black box of Jagex servers that provide all similar data. This project uses
+ * the term `leaderboard` to refer to the array of entries containing [ranks, player names, levels, xp values],
+ * ordered by rank for a single skill.
+ */
+@Slf4j
+@Singleton
+public class LeaderboardManager {
+    @Inject
+    private Client client;
+
+    @Inject
+    private HiscoreClient hiscoreClient;
+
+    @Inject
+    private LeaderboardClient leaderboardClient;
+
+    @Inject
+    private MilestoneLevelsConfig config;
+
+    private static final int MIN_LEADERBOARD_SIZE = 100;
+    private static final int MAX_REQUEST_RETRIES = 3;
+    // The minimum level required in a skill before leaderboard tracking begins. The lower the player's level, the more
+    // densely packed the leaderboards should be. A densely packed leaderboard defeats the purpose of these sorts of
+    // milestones, and results in lots of outgoing requests to the hiscore servers. This acts as a first line of defense
+    // for rate limiting, out of respect to Jagex.
+    private static final int MIN_REQUIRED_LEVEL_FOR_TRACKING = 60;
+
+    // State machine indicating the 3 main stages of operation, and an error state that ceases operation.
+    private LeaderboardManagerState state = LeaderboardManagerState.AWAITING_PLAYER_NAME;
+
+    // Future that is completed after the player's hiscore data is fetched from the hiscore server.
+    private Future<HiscoreResult> hiscoreFuture = null;
+
+    // Holds a complete, valid version of the player's hiscore data after it has been fetched from the hiscore server.
+    private HiscoreResult playerHiscore = null;
+
+    // Tracks retries for fetching player hiscore data.
+    private int hiscoreRetryCount = 0;
+
+    private final Map<Skill, LeaderboardSkillState> skillStates = new EnumMap<>(Skill.class);
+
+    LeaderboardManager() {
+        reset();
+    }
+
+    public void process(GameTick event) {
+        switch (state) {
+            case AWAITING_PLAYER_NAME:
+                processAwaitingPlayerName();
+                break;
+            case AWAITING_PLAYER_HISCORE:
+                processAwaitingPlayerHiscore();
+                break;
+            case ACTIVE:
+                processActive();
+                break;
+            case UNRECOVERABLE_ERROR:
+                // cease operation.
+                break;
+        }
+    }
+
+    /**
+     * Returns all `LeaderboardEntry` values for a skill whose xp value lies between previousXP and currentXP exclusive.
+     *
+     * @param skill Skill
+     * @param previousXp int
+     * @param currentXp int
+     * @return List<LeaderboardEntry>
+     */
+    public List<LeaderboardEntry> getMilestoneLeaderboardEntries(Skill skill, int previousXp, int currentXp) {
+        LeaderboardSkillState skillState = skillStates.get(skill);
+        return skillState.validLeaderboardEntries.stream()
+                                                 .filter(entry -> entry.xp > previousXp && entry.xp < currentXp)
+                                                 .distinct()
+                                                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Set LeaderboardManager to the state it should be in on initialization.
+     */
+    public void reset() {
+        state = LeaderboardManagerState.AWAITING_PLAYER_NAME;
+        hiscoreFuture = null;
+        playerHiscore = null;
+        hiscoreRetryCount = 0;
+        for (Skill s: Skill.values()) {
+            skillStates.put(s, new LeaderboardSkillState());
+        }
+    }
+
+    private void processAwaitingPlayerName() {
+        if (client.getGameState() == GameState.LOGGED_IN && client.getLocalPlayer() != null && client.getLocalPlayer().getName() != null) {
+            if (hiscoreFuture != null) {
+                log.error("Already had a future for player hiscore data when entering the AWAITING_PLAYER_HISCORE state.");
+                state = LeaderboardManagerState.UNRECOVERABLE_ERROR;
+                return;
+            }
+            hiscoreFuture = hiscoreClient.lookupAsync(client.getLocalPlayer().getName(), config.hiscoreEndpoint());
+            state = LeaderboardManagerState.AWAITING_PLAYER_HISCORE;
+        }
+    }
+
+    private void processAwaitingPlayerHiscore() {
+        if (hiscoreFuture == null) {
+            // This is effectively an assert. Reaching this point indicates a programming error.
+            log.error("Missing future when waiting for player hiscore data.");
+            state = LeaderboardManagerState.UNRECOVERABLE_ERROR;
+            return;
+        }
+
+        if (hiscoreFuture.isDone()) {
+            try {
+                playerHiscore = hiscoreFuture.get();
+                ingestPlayerHiscoreData();
+                state = LeaderboardManagerState.ACTIVE;
+                hiscoreFuture = null;
+            } catch (ExecutionException e) {
+                log.warn("Encountered an exception when trying to fetch player specific hiscore data.", e);
+                if (hiscoreRetryCount < MAX_REQUEST_RETRIES) {
+                    hiscoreFuture = hiscoreClient.lookupAsync(client.getLocalPlayer().getName(), config.hiscoreEndpoint());
+                    hiscoreRetryCount++;
+                } else {
+                    log.warn("Reached max retries when fetching player specific hiscore data. Stopping.");
+                    state = LeaderboardManagerState.UNRECOVERABLE_ERROR;
+                }
+            } catch (InterruptedException e) {
+                log.warn("Attempt to fetch player specific hiscore data was interrupted. Stopping.", e);
+                state = LeaderboardManagerState.UNRECOVERABLE_ERROR;
+            }
+        }
+    }
+
+    /**
+     * Updates all LeaderboardSkillStates based on information contained within the player's hiscore data. This must be
+     * called after that data becomes available and before active processing begins.
+     */
+    private void ingestPlayerHiscoreData() {
+        for (Skill s: Skill.values()) {
+            skillStates.get(s).lowestMeasuredRank = playerHiscore.getSkill(HiscoreSkill.valueOf(s.name())).getRank();
+        }
+    }
+
+    /**
+     * Steady state processing that happens every game tick. Loop over all skills, and ensure that for all the tracked
+     * skills, the list of XP milestones is growing until it reaches the adequate length.
+     */
+    private void processActive() {
+        for (Skill s: Skill.values()) {
+            if (Util.skillEnabledInConfig(config, s)) {
+                processSkill(s);
+            }
+        }
+    }
+
+    private void processSkill(Skill skill) {
+        LeaderboardSkillState skillState = skillStates.get(skill);
+        if (skillState.isDisabledFromError ||
+            skillState.lowestMeasuredRank <= 1 ||
+            playerHiscore.getSkill(HiscoreSkill.valueOf(skill.name())).getLevel() < MIN_REQUIRED_LEVEL_FOR_TRACKING) {
+            return;
+        }
+
+        // There might already be an outgoing request for more leaderboard data. Nothing can be done until this is
+        // future is completed.
+        if (skillState.leaderboardFuture != null) {
+            if (!skillState.leaderboardFuture.isDone()) {
+                return;
+            }
+
+            try {
+                // Success case: we just got a new leaderboard page. Now add that data to `skillState`.
+                LeaderboardResult leaderboardResult = skillState.leaderboardFuture.get();
+                skillState.leaderboardFuture = null;
+                skillState.currentPageRetryCount = 0;
+
+                // The results are ordered high XP to low XP since reading begins at the top of the page. Even though
+                // the hiscores change over time, all results from this page will be a greater than or equal to the
+                // highest XP value from the previous page.
+                //
+                // It's possible that several people have the same XP for the current skill. This is especially probable
+                // at low
+                //
+                // There might be some duplicate names on this list that increased their rank since last time we
+                // checked. It's hard to say how this ought to be handled. The leaderboard is constantly changing and
+                // this plugin is using an approximation of the current leaderboar state. For now, duplicates will
+                // be allowed.
+                ArrayList<LeaderboardEntry> resultEntries = new ArrayList<>(leaderboardResult.getEntries());
+                Collections.reverse(resultEntries);
+
+                skillState.validLeaderboardEntries.addAll(resultEntries);
+
+                // De-dupe XP values, only keeping the best (lowest numerical) rank.
+                // TODO: Maybe revisit. This is O(n^2) and it doesn't need to be. Shouldn't matter for small lists.
+                for (int i = 0; i < skillState.validLeaderboardEntries.size()-1; i++) {
+                    if (skillState.validLeaderboardEntries.get(i).xp == skillState.validLeaderboardEntries.get(i+1).xp) {
+                        skillState.validLeaderboardEntries.remove(i);
+                        i--;
+                    }
+                }
+
+                // Rank is in decreasing order, meaning the final element is the lowest rank numerically.
+                skillState.lowestMeasuredRank =
+                        skillState.validLeaderboardEntries.get(skillState.validLeaderboardEntries.size()-1).rank;
+            } catch (ExecutionException e) {
+                // Error handling has lots of failure cases. We only want to retry if there was some sort of network
+                // issue, which would manifest as an IOException wrapped with an ExecutionException from the future.
+                Throwable cause = e.getCause();
+                if (cause instanceof ParseException) {
+                    log.warn("Failed to parse fetched hiscore data for skill: {}. Disabling future lookups for that skill.", skill, cause);
+                    skillState.isDisabledFromError = true;
+                } else if (cause instanceof IOException && skillState.currentPageRetryCount < MAX_REQUEST_RETRIES) {
+                    log.warn("Failed to fetch hiscore data for skill: {} due to possible network issue. Retrying.", skill, cause);
+                        skillState.currentPageRetryCount++;
+                        skillState.leaderboardFuture = null;
+                        requestMoreLeaderboardDataForSkill(skill);
+                } else if (cause instanceof IOException) {
+                    log.warn("Failed to fetch hiscore data for skill: {} due to possible network issue. Reached max retries.", skill, cause);
+                        skillState.isDisabledFromError = true;
+                } else {
+                    log.warn("Failed to fetch hiscore data for skill: {}. Cause was unexpected. Disabling future lookups for that skill.", skill, cause);
+                    skillState.isDisabledFromError = true;
+                }
+
+            } catch (InterruptedException e) {
+                log.warn("Attempt to fetch data for skill: {} was interrupted. Disabling future lookups for that skill.", skill, e);
+                skillState.isDisabledFromError = true;
+            }
+
+        }
+        if (skillState.leaderboardFuture != null) {
+            return;
+        }
+        // This point should now only be reached if there is no leaderboardFuture (it's possible that there was one when
+        // this function was initially called).
+
+        // Trim the list of leaderboard entries to remove all XP milestones lower than the player's current XP value for
+        // this skill.
+        skillState.validLeaderboardEntries =
+                skillState.validLeaderboardEntries.stream()
+                                                  .filter(entry -> entry.xp > client.getSkillExperience(skill))
+                                                  .distinct()
+                                                  .collect(Collectors.toList());
+
+        if (skillState.validLeaderboardEntries.size() < MIN_LEADERBOARD_SIZE) {
+            requestMoreLeaderboardDataForSkill(skill);
+        }
+    }
+
+    /**
+     * Helper function that initiates a request for the next leaderboard page for a skill.
+     */
+    private void requestMoreLeaderboardDataForSkill(Skill skill) {
+        LeaderboardSkillState skillState = skillStates.get(skill);
+        if (skillState.leaderboardFuture != null) {
+            log.warn("Attempted to fetch more leaderboard data for skill: {} while a request was already pending. Disabling future lookups.", skill);
+            skillState.isDisabledFromError = true;
+            return;
+        }
+
+        int nextRankToMeasure = skillState.lowestMeasuredRank - 1;
+        if (nextRankToMeasure <= 0) {
+            return;
+        }
+
+        // For example: page 2 contains ranks 26 to 50 inclusive.
+        //   ((25-1) / 25) + 1 == 1
+        //   ((26-1) / 25) + 1 == 2
+        //   ((50-1) / 25) + 1 == 2
+        //   ((51-1) / 25) + 1 == 3
+        int pageToRequest = ((nextRankToMeasure - 1) / 25) + 1;
+
+        skillState.leaderboardFuture = leaderboardClient.lookupAsync(
+                skill, pageToRequest, LeaderboardEndpoint.valueOf(config.hiscoreEndpoint().name()));
+    }
+
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardManagerState.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardManagerState.java
@@ -1,0 +1,23 @@
+package com.antimated.leaderboard;
+
+/**
+ * Possible states for the LeaderboardManager state machine.
+ *
+ * See LeaderboardManager for implementation details and notes.
+ */
+public enum LeaderboardManagerState {
+    // The first step is for the LeaderboardManager to get the player's name for leaderboard lookup. This is not
+    // available until the player is logged in and gameplay is active.
+    AWAITING_PLAYER_NAME,
+    // After the player name is available, the LeaderboardManager immediately issues a request to the hiscores API for
+    // that player's full hiscore state, which is kept steady until the player logs out or hops.
+    AWAITING_PLAYER_HISCORE,
+    // If player hiscore data is available, the LeaderboardManager has a starting point for querying leaderboard pages.
+    // This means it is in the active state where it is continually trying to upkeep lists of XP milestones for the
+    // player to pass.
+    ACTIVE,
+    // Failsafe to stop all operation of the LeaderboardManager after an error that doesn't have recovery logic
+    // implemented. Effectively prefer turning the submodule off over having it run in a weird state, potentially
+    // spamming requests to the OSRS hiscores website, slowing the server down, and slowing down the player's client.
+    UNRECOVERABLE_ERROR,
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardParser.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardParser.java
@@ -1,0 +1,53 @@
+package com.antimated.leaderboard;
+
+import okhttp3.Response;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+
+/**
+ * Provides parsing logic for leaderboard HTML documents. `LeaderboardParser` depends on the structure of the OSRS
+ * hiscores pages keeping the same format, meaning this is one of the classes that's most likely to break as Jagex
+ * introduces changes to their website.
+ */
+public class LeaderboardParser {
+    /**
+     * Parses the unstructured `documentContents` into a LeaderboardResult.
+     *
+     * @param documentContents String
+     * @return LeaderboardResult
+     * @throws ParseException when parsing of the document fails for any reason.
+     */
+    public static LeaderboardResult parseDocument(String documentContents) throws ParseException {
+        Document document = Jsoup.parse(documentContents);
+        Element tableOuterDiv = document.getElementById("contentHiscores");
+        Element table = tableOuterDiv.selectFirst("table");
+        Element tableBody = table.selectFirst("tbody");
+        Elements rows = tableBody.children();
+
+        ArrayList<LeaderboardEntry> entries = new ArrayList<LeaderboardEntry>();
+        for (Element row: rows.asList()) {
+            Elements tableData = row.children();
+            // Element spaceElement = tableData.get(0);
+            Element rankElement = tableData.get(1);
+            Element nameElement = tableData.get(2);
+            Element nameAElement = nameElement.firstElementChild();
+            Element levelElement = tableData.get(3);
+            Element xpElement = tableData.get(4);
+
+            int rank = NumberFormat.getNumberInstance(java.util.Locale.US).parse(rankElement.text()).intValue();
+            String name = nameAElement.text();
+            int level = Integer.parseInt(levelElement.text());
+            int xp = NumberFormat.getNumberInstance(java.util.Locale.US).parse(xpElement.text()).intValue();
+            LeaderboardEntry entry = new LeaderboardEntry(name, rank, level, xp);
+            entries.add(entry);
+        }
+        return new LeaderboardResult(entries);
+    }
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardResult.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardResult.java
@@ -1,0 +1,19 @@
+package com.antimated.leaderboard;
+
+import lombok.Value;
+import net.runelite.api.Skill;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Array of LeaderboardEntries that result from requesting and processing a single page from the OSRS hiscores website.
+ */
+@Value
+public class LeaderboardResult {
+    private List<LeaderboardEntry> entries;
+
+    public List<LeaderboardEntry> getEntries() {
+        return Collections.unmodifiableList(entries);
+    }
+}

--- a/src/main/java/com/antimated/leaderboard/LeaderboardSkillState.java
+++ b/src/main/java/com/antimated/leaderboard/LeaderboardSkillState.java
@@ -1,0 +1,30 @@
+package com.antimated.leaderboard;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * "POD" object that contains all data relevant to managing queries over leaderboard data for a single skill.
+ *
+ * See LeaderboardManager for implementation details and notes.
+ */
+public class LeaderboardSkillState {
+    // Indicates whether leaderboard tracking of this skill has been disabled due to an error.
+    public boolean isDisabledFromError = false;
+
+    // Indicates the number of retries that have been made on the current leaderboard page. Resets to zero after
+    // successfully processing a page.
+    public int currentPageRetryCount = 0;
+
+    // If not null, this is the Future pending an active request for leaderboard data.
+    public Future<LeaderboardResult> leaderboardFuture = null;
+
+    // The lowest rank that has been measured on the leaderboard. Gets set to the player's current rank upon entering
+    // the active state. It is used to determine which page to search for data. "Lowest" in this case means lowest
+    // numerically, where rank 1 is lower than rank 2.
+    public int lowestMeasuredRank = 0;
+
+    // List of leaderboard entries that are currently being used to
+    public List<LeaderboardEntry> validLeaderboardEntries = new ArrayList<LeaderboardEntry>();
+}

--- a/src/main/java/com/antimated/leaderboard/SkillTable.java
+++ b/src/main/java/com/antimated/leaderboard/SkillTable.java
@@ -1,0 +1,37 @@
+package com.antimated.leaderboard;
+
+/**
+ * Maps skills to leaderboard table numbers from the OSRS hiscores website.
+ */
+public enum SkillTable {
+    ATTACK(1),
+    DEFENCE(2),
+    STRENGTH(3),
+    HITPOINTS(4),
+    RANGED(5),
+    PRAYER(6),
+    MAGIC(7),
+    COOKING(8),
+    WOODCUTTING(9),
+    FLETCHING(10),
+    FISHING(11),
+    FIREMAKING(12),
+    CRAFTING(13),
+    SMITHING(14),
+    MINING(15),
+    HERBLORE(16),
+    AGILITY(17),
+    THIEVING(18),
+    SLAYER(19),
+    FARMING(20),
+    RUNECRAFT(21),
+    HUNTER(22),
+    CONSTRUCTION(23),
+    SAILING(24);
+
+    public final int tableNumber;
+
+    SkillTable(int tableNumber) {
+        this.tableNumber = tableNumber;
+    }
+}

--- a/src/main/java/com/antimated/util/Util.java
+++ b/src/main/java/com/antimated/util/Util.java
@@ -1,6 +1,8 @@
 package com.antimated.util;
 
 import java.awt.Color;
+
+import com.antimated.MilestoneLevelsConfig;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
@@ -100,6 +102,70 @@ public class Util
 		return Text.escapeJagex(text
 			.replaceAll("\\$skill", skill.getName())
 			.replaceAll("\\$xp", QuantityFormatter.formatNumber(xp)));
+	}
+
+	/**
+	 * Check if notification for a skill is enabled in the config.
+	 *
+	 * @param config MilestoneLevelsConfig
+	 * @param skill Skill
+	 * @return boolean
+	 */
+	public static boolean skillEnabledInConfig(MilestoneLevelsConfig config, Skill skill)
+	{
+		switch (skill)
+		{
+			case ATTACK:
+				return config.showAttackNotifications();
+			case DEFENCE:
+				return config.showDefenceNotifications();
+			case STRENGTH:
+				return config.showStrengthNotifications();
+			case HITPOINTS:
+				return config.showHitpointsNotifications();
+			case RANGED:
+				return config.showRangedNotifications();
+			case PRAYER:
+				return config.showPrayerNotifications();
+			case MAGIC:
+				return config.showMagicNotifications();
+			case COOKING:
+				return config.showCookingNotifications();
+			case WOODCUTTING:
+				return config.showWoodcuttingNotifications();
+			case FLETCHING:
+				return config.showFletchingNotifications();
+			case FISHING:
+				return config.showFishingNotifications();
+			case FIREMAKING:
+				return config.showFiremakingNotifications();
+			case CRAFTING:
+				return config.showCraftingNotifications();
+			case SMITHING:
+				return config.showSmithingNotifications();
+			case MINING:
+				return config.showMiningNotifications();
+			case HERBLORE:
+				return config.showHerbloreNotifications();
+			case AGILITY:
+				return config.showAgilityNotifications();
+			case THIEVING:
+				return config.showThievingNotifications();
+			case SLAYER:
+				return config.showSlayerNotifications();
+			case FARMING:
+				return config.showFarmingNotifications();
+			case RUNECRAFT:
+				return config.showRunecraftNotifications();
+			case HUNTER:
+				return config.showHunterNotifications();
+			case CONSTRUCTION:
+				return config.showConstructionNotifications();
+			case SAILING:
+				return config.showSailingNotifications();
+		}
+
+		return true;
 	}
 
 	public static boolean isStandardWorld(Client client)

--- a/src/main/java/com/antimated/util/Util.java
+++ b/src/main/java/com/antimated/util/Util.java
@@ -3,6 +3,7 @@ package com.antimated.util;
 import java.awt.Color;
 
 import com.antimated.MilestoneLevelsConfig;
+import com.antimated.leaderboard.LeaderboardEntry;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
@@ -102,6 +103,25 @@ public class Util
 		return Text.escapeJagex(text
 			.replaceAll("\\$skill", skill.getName())
 			.replaceAll("\\$xp", QuantityFormatter.formatNumber(xp)));
+	}
+
+
+	/** Replaces the words $skill, $xp, $rank, and $player from the text to the passed skill and data from
+	 * leaderboardEntry
+	 *
+	 * @param text  String
+	 * @param skill Skill
+	 * @param leaderboardEntry LeaderboardEntry
+	 * @return String
+	 */
+	public static String replaceLeaderboardValues(String text, Skill skill, LeaderboardEntry leaderboardEntry)
+	{
+		return Text.escapeJagex(text
+				.replaceAll("\\$skill", skill.getName())
+				.replaceAll("\\$xp", QuantityFormatter.formatNumber(leaderboardEntry.xp))
+				.replaceAll("\\$rank", QuantityFormatter.formatNumber(leaderboardEntry.rank))
+				.replaceAll("\\$player", leaderboardEntry.name)
+				.replaceAll("\\$name", leaderboardEntry.name));
 	}
 
 	/**


### PR DESCRIPTION
Adds functionality to `MilestoneLevelsPlugin` to support using the [osrs hiscores](https://secure.runescape.com/m=hiscore_oldschool/overall) website as a source for level milestones. Introduces a package called `leaderboard` that provides the functionality for requesting, parsing, and organizing the hiscore data to be used by `MilestoneLevelsPlugin`. The term `leaderboard` is used to disambiguate from RuneLite's existing use of "hiscore" to refer to a [player's specific hiscore page](https://secure.runescape.com/m=hiscore_oldschool/hiscorepersonal?user1=Zezima).

<img width="227" height="346" alt="Screenshot_20260203_195243" src="https://github.com/user-attachments/assets/9d7d638c-45ec-4054-bd52-3cf6d94f8b71" />
<img width="962" height="580" alt="Screenshot_20260203_195155" src="https://github.com/user-attachments/assets/61ba1563-4365-4c4c-804f-916b235718b9" />
